### PR TITLE
36120: Add a Dockerfile to automate TICSQtCreator plugin build steps and fix issue in the field

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,83 @@
+ARG DISTRO='ubuntu'
+ARG VERSION='20.04'
+FROM ${DISTRO}:${VERSION}
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Build arguments.
+ARG UPDATE_PACKAGES='apt-get update'
+ARG INSTALL_PACKAGES='apt-get install -y'
+ARG CLEAN_PACKAGES='rm -rf /var/lib/apt/lists/*'
+
+# Install necessary tools for building.
+RUN ${UPDATE_PACKAGES}  && \
+    ${INSTALL_PACKAGES} wget build-essential cmake ninja-build git p7zip-full python-is-python3 python2
+
+# Install necessary dependencies for building Qt and Qt Creator
+RUN ${INSTALL_PACKAGES} libgl1-mesa-dev libvulkan-dev libxcb-xinput-dev libxcb-xinerama0-dev libxkbcommon-dev libxkbcommon-x11-dev libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xkb1 libxcb-randr0 libxcb-icccm4 && \
+    ${INSTALL_PACKAGES} libglib2.0-dev libsm-dev libxrender-dev libfontconfig1-dev libxext-dev libfreetype6-dev libx11-dev libxcursor-dev libxfixes-dev libxft-dev libxi-dev libxrandr-dev libgl-dev libglu-dev && \
+    ${INSTALL_PACKAGES} libxml2 libxml2-dev && \
+    ${INSTALL_PACKAGES} gperf bison flex
+
+# Install Gcc of a specific version.
+ARG GCC_VERSION='7'
+RUN ${UPDATE_PACKAGES} && \
+    ${INSTALL_PACKAGES} g++-${GCC_VERSION} && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} ${GCC_VERSION} --slave /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION}
+
+# Install LLVM of a specific version.
+ARG LLVM_ARCHIVE='libclang-release_80-based-linux-Ubuntu16.04-gcc5.3-x86_64.7z'
+ARG LLVM_ARCHIVE_URL=https://download.qt.io/development_releases/prebuilt/libclang/${LLVM_ARCHIVE}
+RUN mkdir llvm && \
+    cd llvm && \
+    mkdir llvm-pkg && \
+    wget ${LLVM_ARCHIVE_URL} && \
+    7z x ${LLVM_ARCHIVE} -o/llvm/llvm-pkg
+
+# Install Qt 5.*.*
+ARG QT_ARCHIVE_PKG='qt-everywhere-src-5.12.8'
+ARG QT_ARCHIVE_FILE=${QT_ARCHIVE_PKG}.tar.xz
+ARG QT_ARCHIVE_URL='https://download.qt.io/archive/qt/5.12/5.12.8/single/qt-everywhere-src-5.12.8.tar.xz'
+RUN mkdir qt && \
+    cd qt && \
+    wget ${QT_ARCHIVE_URL}
+RUN cd qt && \
+    tar xf ${QT_ARCHIVE_FILE}
+
+RUN cd /qt && \
+    mkdir qtbase && \
+    cd /qt/${QT_ARCHIVE_PKG} && \
+    ./configure -opensource -confirm-license -nomake tests -nomake examples -prefix /qt/qtbase -skip qt3d -skip qtquick3d -skip qtgamepad \
+    -skip qtspeech -skip qtdoc -skip qtsensors -skip qtdatavis3d -skip qtcharts -skip qtandroidextras -skip qtmacextras -skip qtvirtualkeyboard \
+    -skip qtcharts -skip qtpurchasing -skip qtserialbus -skip qtserialport -skip qtlocation
+RUN cd /qt/${QT_ARCHIVE_PKG} && \
+    export LLVM_HOME=/llvm/llvm-pkg/libclang && \
+    export PATH=$LLVM_HOME/bin:$PATH && \
+    export LD_LIBRARY_PATH=$LLVM_HOME/lib:$LD_LIBRARY_PATH && \
+    make -j4 > qtbuildoutput.txt 2>qtbuilderror.txt
+RUN cd /qt/${QT_ARCHIVE_PKG} && \
+    make install
+
+# Build Qt Creator 4.*.*
+ARG QT_CREATOR_VERSION='4.11.0'
+ARG QT_CREATOR_TAG=v${QT_CREATOR_VERSION}
+
+# Check out the correct Qt Creator branch to build with
+RUN git clone https://github.com/qt-creator/qt-creator.git && \
+    cd qt-creator && \
+    git checkout -b ${QT_CREATOR_VERSION} ${QT_CREATOR_TAG}
+
+RUN mkdir qt-creator-build && \
+    cd /qt-creator-build && \
+    export PATH=$PATH:/qt/qtbase/bin && \
+    export LLVM_INSTALL_DIR=/llvm/llvm-pkg/libclang && \
+    qmake -r ../qt-creator && \
+    make -j8 > qtcreatorbuildoutput.txt 2>qtcreatorbuilderror.txt
+
+# Build TICS Qt Plugin
+ARG QT_CREATOR_DEFAULT_VERSION='4.12.2'
+RUN git clone https://github.com/tiobe/TICSQtCreator.git && \
+    cd TICSQtCreator && \
+    sed -i s/${QT_CREATOR_DEFAULT_VERSION}/${QT_CREATOR_VERSION}/g TICSQtCreator.json && \
+    export PATH=$PATH:/qt/qtbase/bin && \
+    qmake IDE_SOURCE_TREE=/qt-creator IDE_BUILD_TREE=/qt-creator-build && \
+    make

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir llvm && \
     wget ${LLVM_ARCHIVE_URL} && \
     7z x ${LLVM_ARCHIVE} -o/llvm/llvm-pkg
 
-# Install Qt 5.*.*
+# Build and install Qt 5.*.*
 ARG QT_ARCHIVE_PKG='qt-everywhere-src-5.12.8'
 ARG QT_ARCHIVE_FILE=${QT_ARCHIVE_PKG}.tar.xz
 ARG QT_ARCHIVE_URL='https://download.qt.io/archive/qt/5.12/5.12.8/single/qt-everywhere-src-5.12.8.tar.xz'
@@ -42,13 +42,18 @@ RUN mkdir qt && \
     wget ${QT_ARCHIVE_URL}
 RUN cd qt && \
     tar xf ${QT_ARCHIVE_FILE}
-
+      
+ARG QT_CONFIGURE_CMD='./configure -opensource -confirm-license -nomake tests -nomake examples -prefix /qt/qtbase -skip qt3d -skip qtgamepad -skip qtspeech -skip qtdoc -skip qtsensors -skip qtdatavis3d -skip qtcharts -skip qtandroidextras -skip qtmacextras -skip qtvirtualkeyboard -skip qtcharts -skip qtpurchasing -skip qtserialbus -skip qtserialport -skip qtlocation -skip qtconnectivity -skip qttranslations'
+ARG SKIP_QUICK3D='-skip qtquick3d' 
 RUN cd /qt && \
     mkdir qtbase && \
     cd /qt/${QT_ARCHIVE_PKG} && \
-    ./configure -opensource -confirm-license -nomake tests -nomake examples -prefix /qt/qtbase -skip qt3d -skip qtquick3d -skip qtgamepad \
-    -skip qtspeech -skip qtdoc -skip qtsensors -skip qtdatavis3d -skip qtcharts -skip qtandroidextras -skip qtmacextras -skip qtvirtualkeyboard \
-    -skip qtcharts -skip qtpurchasing -skip qtserialbus -skip qtserialport -skip qtlocation
+    if [ -d /qt/${QT_ARCHIVE_PKG}/qtquick3d ]; then \
+      ${QT_CONFIGURE_CMD} ${SKIP_QUICK3D}; \
+    else \
+      ${QT_CONFIGURE_CMD}; \
+    fi;
+     
 RUN cd /qt/${QT_ARCHIVE_PKG} && \
     export LLVM_HOME=/llvm/llvm-pkg/libclang && \
     export PATH=$LLVM_HOME/bin:$PATH && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,8 +75,10 @@ RUN mkdir qt-creator-build && \
 
 # Build TICS Qt Plugin
 ARG QT_CREATOR_DEFAULT_VERSION='4.12.2'
+ARG TICS_QT_GIT_BRANCH='main'
 RUN git clone https://github.com/tiobe/TICSQtCreator.git && \
     cd TICSQtCreator && \
+    git checkout ${TICS_QT_GIT_BRANCH} && \
     sed -i s/${QT_CREATOR_DEFAULT_VERSION}/${QT_CREATOR_VERSION}/g TICSQtCreator.json && \
     export PATH=$PATH:/qt/qtbase/bin && \
     qmake IDE_SOURCE_TREE=/qt-creator IDE_BUILD_TREE=/qt-creator-build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,15 +57,14 @@ RUN cd /qt/${QT_ARCHIVE_PKG} && \
 RUN cd /qt/${QT_ARCHIVE_PKG} && \
     make install
 
-# Build Qt Creator 4.*.*
+# Check out the correct Qt Creator branch to build with
 ARG QT_CREATOR_VERSION='4.11.0'
 ARG QT_CREATOR_TAG=v${QT_CREATOR_VERSION}
-
-# Check out the correct Qt Creator branch to build with
 RUN git clone https://github.com/qt-creator/qt-creator.git && \
     cd qt-creator && \
     git checkout -b ${QT_CREATOR_VERSION} ${QT_CREATOR_TAG}
 
+# Build Qt Creator 4.*.*
 RUN mkdir qt-creator-build && \
     cd /qt-creator-build && \
     export PATH=$PATH:/qt/qtbase/bin && \

--- a/README.md
+++ b/README.md
@@ -68,23 +68,18 @@ Building the Qt Creator Plugin
 
 Using Dockerfile to Automate the Qt Creator Plugin Build
 --------------------------------------------------------
-<<<<<<< HEAD
+
 You can use the provided Dockerfile to build and get a working TICS Qt Creator Plugin artifact for a specific target platform.
 Note that this Dockerfile is written for target platform Qt Creator 4.x.x based on Qt 5.x.x. Target platforms with different major versions than those may require different build steps.
-=======
+
 You can use the provided Dockerfile to build and get a working TICS Qt Creator Plugin artifact for specific target platforms.
->>>>>>> daf1fbe8fb50a4012e5b596a0b8def70b0f92c5d
 The arguments used for parameterizing specific target platforms and their values are shown below:
 
 <pre>
 DISTRO=ubuntu
 VERSION=20.04
 GCC_VERSION=7
-<<<<<<< HEAD
 LLVM_ARCHIVE=libclang-release_80-based-linux-Ubuntu16.04-gcc5.3-x86_64.7z
-=======
-LLVM_ARCHIVE=libclang-release_80-based-linux-Ubuntu16.04-gcc5.3-x86_64.7z  
->>>>>>> daf1fbe8fb50a4012e5b596a0b8def70b0f92c5d
 QT_ARCHIVE_PKG=qt-everywhere-src-5.12.8
 QT_ARCHIVE_URL=https://download.qt.io/archive/qt/5.12/5.12.8/single/qt-everywhere-src-5.12.8.tar.xz
 QT_CREATOR_VERSION=4.11.0
@@ -92,7 +87,6 @@ TICS_QT_GIT_BRANCH=main
 </pre>
 
 You can change the values of these arguments based on your desired target platforms when building the Dockerfile. The following command shows an example of building the TICS Qt Creator plugin for target platform Qt Creator 4.12.2 based on Qt 5.14.2:
-
 ```
 docker build --build-arg GCC_VERSION=7 --build-arg QT_ARCHIVE_PKG=qt-everywhere-src-5.14.2 --build-arg QT_ARCHIVE_URL=https://download.qt.io/archive/qt/5.14/5.14.2/single/qt-everywhere-src-5.14.2.tar.xz  --build-arg QT_CREATOR_VERSION=4.12.2 -t ticsqtcreator:4-12-2 .
 ```
@@ -100,13 +94,9 @@ The command above will create an image with the tag `ticsqtcreator:4-12-2`. The 
 
 ```
 docker run -it -d --name ticsqtcreator fddf7a31202a
-docker cp ticsqtcreator:/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so /home/leila/Development/QtDocker/v4
+docker cp ticsqtcreator:/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so /home/leila/Development/QtDocker
 ```
 
-<<<<<<< HEAD
-
-=======
->>>>>>> daf1fbe8fb50a4012e5b596a0b8def70b0f92c5d
 ## References
 - [Qt wiki page on building QT creator from sources](https://wiki.qt.io/Building_Qt_Creator_from_Git)
 - [A working example of Qt Creator with tutorial](http://blog.davidecoppola.com/2019/12/how-to-create-a-qt-creator-plugin/)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ Building the Qt Creator Plugin
 - another (better) option is to set the <code>QTC_BUILD</code> and QTC_SOURCE</code> system environment variables
 - To test, run your Qt Creator build from <code><YOUR_QT_CREATOR_BUILD_DIR>/bin/qtcreator</code>
 
+Using Dockerfile to Automate the Qt Creator Plugin Build
+--------------------------------------------------------
+You can use the provided Dockerfile to build and get a working TICS Qt Creator Plugin artifact for a specific target platform.
+Note that this Dockerfile is written for target platform Qt Creator 4.x.x based on Qt 5.x.x. Target platforms with different major versions than those may require different build steps.
+The arguments used for parameterizing specific target platforms and their values are shown below:
+
+<pre>
+DISTRO=ubuntu
+VERSION=20.04
+GCC_VERSION=7
+LLVM_ARCHIVE=libclang-release_80-based-linux-Ubuntu16.04-gcc5.3-x86_64.7z
+QT_ARCHIVE_PKG=qt-everywhere-src-5.12.8
+QT_ARCHIVE_URL=https://download.qt.io/archive/qt/5.12/5.12.8/single/qt-everywhere-src-5.12.8.tar.xz
+QT_CREATOR_VERSION=4.11.0
+TICS_QT_GIT_BRANCH=main
+</pre>
+
+You can change the values of these arguments based on your desired target platforms when building the Dockerfile. The following command shows an example of building the TICS Qt Creator plugin for target platform Qt Creator 4.12.2 based on Qt 5.14.2:
+
+```
+docker build --build-arg GCC_VERSION=7 --build-arg QT_ARCHIVE_PKG=qt-everywhere-src-5.14.2 --build-arg QT_ARCHIVE_URL=https://download.qt.io/archive/qt/5.14/5.14.2/single/qt-everywhere-src-5.14.2.tar.xz  --build-arg QT_CREATOR_VERSION=4.12.2 -t ticsqtcreator:4-12-2 .
+```
+The command above will create an image with the tag `ticsqtcreator:4-12-2`. The TICS Qt Creator plugin artifact will be located in `/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so`. To get the artifact from the created image to the host file system, you can first run a container from the created image, then perform a docker copy as shown in the following commands examples:
+
+```
+docker run -it -d --name ticsqtcreator fddf7a31202a
+docker cp ticsqtcreator:/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so /home/leila/Development/QtDocker/v4
+```
+
+
 ## References
 - [Qt wiki page on building QT creator from sources](https://wiki.qt.io/Building_Qt_Creator_from_Git)
 - [A working example of Qt Creator with tutorial](http://blog.davidecoppola.com/2019/12/how-to-create-a-qt-creator-plugin/)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Build Qt Creator from Sources
 
 Building the Qt Creator Plugin
 --------------------------------------
-- For building the plugin you need Qt Creator installed(This Qt creator should be using the same version of Qt and compiler version as the one you build from sources)
+- For building the plugin you need Qt Creator installed (This Qt creator should be using the same version of Qt and compiler version as the one you build from sources)
 - In the plugin's .pro file update the location of the QT Creator source location and the QT Creator build location that you created before
  <pre>
     ## Either set the IDE_SOURCE_TREE when running qmake,
@@ -72,7 +72,6 @@ Using Dockerfile to Automate the Qt Creator Plugin Build
 You can use the provided Dockerfile to build and get a working TICS Qt Creator Plugin artifact for a specific target platform.
 Note that this Dockerfile is written for target platform Qt Creator 4.x.x based on Qt 5.x.x. Target platforms with different major versions than those may require different build steps.
 
-You can use the provided Dockerfile to build and get a working TICS Qt Creator Plugin artifact for specific target platforms.
 The arguments used for parameterizing specific target platforms and their values are shown below:
 
 <pre>
@@ -86,12 +85,30 @@ QT_CREATOR_VERSION=4.11.0
 TICS_QT_GIT_BRANCH=main
 </pre>
 
-You can change the values of these arguments based on your desired target platforms when building the Dockerfile. The following command shows an example of building the TICS Qt Creator plugin for target platform Qt Creator 4.12.2 based on Qt 5.14.2:
+
+You can change the values of these arguments based on your desired target platforms when building the Dockerfile.
+
+Some remarks for building TICS Qt Creator plugin for target platforms Qt creator 4.x.x based on Qt 5.x.x:
+* Does not work with Gcc 9 and higher. Seems to work with Gcc 5-7.
+* Ubuntu 22.04 onwards only support Gcc 9 and higher. Therefore use Ubuntu 20.04 or lower.
+* Does not seem to work with LLVM 10 or higher. Proven to work with LLVM 8.
+* For specific `LLVM_ARCHIVE`, you can find here: https://download.qt.io/development_releases/prebuilt/libclang/.
+* For specific `QT_ARCHIVE_PKG`, and `QT_ARCHIVE_URL` you can find here: https://download.qt.io/archive/qt
+* For specific `QT_CREATOR_VERSION` you can find here:https://download.qt.io/archive/qtcreator/
+
+The following command shows an example of building the TICS Qt Creator plugin for target platform Qt Creator 4.12.2 based on Qt 5.14.2:
 ```
 docker build --build-arg GCC_VERSION=7 --build-arg QT_ARCHIVE_PKG=qt-everywhere-src-5.14.2 --build-arg QT_ARCHIVE_URL=https://download.qt.io/archive/qt/5.14/5.14.2/single/qt-everywhere-src-5.14.2.tar.xz  --build-arg QT_CREATOR_VERSION=4.12.2 -t ticsqtcreator:4-12-2 .
 ```
-The command above will create an image with the tag `ticsqtcreator:4-12-2`. The TICS Qt Creator plugin artifact will be located in `/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so`. To get the artifact from the created image to the host file system, you can first run a container from the created image, then perform a docker copy as shown in the following commands examples:
+The command above will create an image with the tag `ticsqtcreator:4-12-2`. 
 
+The TICS Qt Creator plugin artifact will be located in `/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so`. To get the artifact from the created image to the host file system, you can first run a container from the created image, then perform a docker copy as shown in the following commands and their examples:
+
+```
+docker run -it -d --name <container_name> <image_id>
+docker cp <container_name>:<path_to_plugin_artifact_inside_container> <path_to_target_location_in_host_file_system>
+```
+Examples:
 ```
 docker run -it -d --name ticsqtcreator fddf7a31202a
 docker cp ticsqtcreator:/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so /home/leila/Development/QtDocker

--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ Building the Qt Creator Plugin
 - another (better) option is to set the <code>QTC_BUILD</code> and QTC_SOURCE</code> system environment variables
 - To test, run your Qt Creator build from <code><YOUR_QT_CREATOR_BUILD_DIR>/bin/qtcreator</code>
 
+Using Dockerfile to Automate the Qt Creator Plugin Build
+--------------------------------------------------------
+You can use the provided Dockerfile to build and get a working TICS Qt Creator Plugin artifact for specific target platforms.
+The arguments used for parameterizing specific target platforms and their values are shown below:
+
+<pre>
+DISTRO=ubuntu
+VERSION=20.04
+GCC_VERSION=7
+LLVM_ARCHIVE=libclang-release_80-based-linux-Ubuntu16.04-gcc5.3-x86_64.7z  
+QT_ARCHIVE_PKG=qt-everywhere-src-5.12.8
+QT_ARCHIVE_URL=https://download.qt.io/archive/qt/5.12/5.12.8/single/qt-everywhere-src-5.12.8.tar.xz
+QT_CREATOR_VERSION=4.11.0
+TICS_QT_GIT_BRANCH=main
+</pre>
+
+You can change the values of these arguments based on your desired target platforms when building the Dockerfile. The following command shows an example of building the TICS Qt Creator plugin for target platform Qt Creator 4.12.2 based on Qt 5.14.2:
+
+```
+docker build --build-arg GCC_VERSION=7 --build-arg QT_ARCHIVE_PKG=qt-everywhere-src-5.14.2 --build-arg QT_ARCHIVE_URL=https://download.qt.io/archive/qt/5.14/5.14.2/single/qt-everywhere-src-5.14.2.tar.xz  --build-arg QT_CREATOR_VERSION=4.12.2 -t ticsqtcreator:4-12-2 .
+```
+The command above will create an image with the tag `ticsqtcreator:4-12-2`. The TICS Qt Creator plugin artifact will be located in `/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so`. To get the artifact from the created image to the host file system, you can first run a container from the created image, then perform a docker copy as shown in the following commands examples:
+
+```
+docker run -it -d --name ticsqtcreator fddf7a31202a
+docker cp ticsqtcreator:/qt-creator-build/lib/qtcreator/plugins/libTICSQtCreator.so /home/leila/Development/QtDocker/v4
+```
+
 ## References
 - [Qt wiki page on building QT creator from sources](https://wiki.qt.io/Building_Qt_Creator_from_Git)
 - [A working example of Qt Creator with tutorial](http://blog.davidecoppola.com/2019/12/how-to-create-a-qt-creator-plugin/)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Some remarks for building TICS Qt Creator plugin for target platforms Qt creator
 * Does not seem to work with LLVM 10 or higher. Proven to work with LLVM 8.
 * For specific `LLVM_ARCHIVE`, you can find here: https://download.qt.io/development_releases/prebuilt/libclang/.
 * For specific `QT_ARCHIVE_PKG`, and `QT_ARCHIVE_URL` you can find here: https://download.qt.io/archive/qt
-* For specific `QT_CREATOR_VERSION` you can find here:https://download.qt.io/archive/qtcreator/
+* For specific `QT_CREATOR_VERSION` you can find here: https://download.qt.io/archive/qtcreator/
 
 The following command shows an example of building the TICS Qt Creator plugin for target platform Qt Creator 4.12.2 based on Qt 5.14.2:
 ```

--- a/ticsqtcreator.pro
+++ b/ticsqtcreator.pro
@@ -1,4 +1,5 @@
 DEFINES += TICSQTCREATOR_LIBRARY
+QMAKE_CXXFLAGS += "-fno-sized-deallocation"
 
 # TICSQtCreator files
 


### PR DESCRIPTION
Three things are done in this pull request:

* Add a Dockerfile to automate TICSQtCreator plugin build steps based on https://redmine.tiobe.com/issues/36027#Build-Steps
* Fix issue plugin in the field based on solution https://stackoverflow.com/a/53234995 in file ticsqtcreator.pro
* Add description and instructions on using the Dockerfile to automate the build steps and getting the plugin artifact in the README